### PR TITLE
Add missing support

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -38,6 +38,13 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/22953606?v=4",
       "profile": "https://github.com/mingtianyihou33",
       "contributions": ["code", "test", "ideas"]
+    },
+    {
+      "login": "jordancardwell",
+      "name": "Jordan",
+      "avatar_url": "https://avatars.githubusercontent.com/u/636339?v=4",
+      "profile": "https://github.com/jordancardwell",
+      "contributions": ["a11y", "code", "test"]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -130,58 +130,60 @@ generateDocumentation({
 
 ## :toolbox: Functions
 
-- [buildDocumentation](#gear-builddocumentation)
-- [documentationToMarkdown](#gear-documentationtomarkdown)
-- [generateDocumentation](#gear-generatedocumentation)
+- [buildRunner](#gear-buildrunner)
+- [useCommandRunnerCallback](#gear-usecommandrunnercallback)
+- [useRunnableCommand](#gear-userunnablecommand)
 
-### :gear: buildDocumentation
+### :gear: buildRunner
 
-Build the documentation entries for the selected sources.
+Builds a command runner for the given command name and selection.
+The built runner will have its handler property set to a function that will
+execute all available commands for the given command name.
 
-| Function             | Type                                                                                                      |
-| -------------------- | --------------------------------------------------------------------------------------------------------- |
-| `buildDocumentation` | `({ inputFiles, options }: { inputFiles: string[]; options?: BuildOptions or undefined; }) => DocEntry[]` |
-
-Parameters:
-
-- `params.inputFiles`: The list of files to scan and for which the documentation should be build.
-- `params.options`: Optional compiler options to generate the docs
-
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/docs.ts#L398)
-
-### :gear: documentationToMarkdown
-
-Convert the documentation entries to an opinionated Markdown format.
-
-| Function                  | Type                                                                                                 |
-| ------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `documentationToMarkdown` | `({ entries, options }: { entries: DocEntry[]; options?: MarkdownOptions or undefined; }) => string` |
+| Function | Type |
+| ---------- | ---------- |
+| `buildRunner` | `(name: CommandName, selection: SelectionKey[], arg: string or undefined, isReadOnlyUser: boolean) => RunnableCommandInternal` |
 
 Parameters:
 
-- `params.entries`: The entries of the documentation (functions, constants and classes).
-- `params.options`: Optional configuration to render the Markdown content. See `types.ts` for details.
+* `name`: The name of the command to build a runner for
+* `selection`: The current selection
+* `arg`: The argument to pass to the command
+* `isReadOnlyUser`: Whether the current user is read-only
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L277)
 
-### :gear: generateDocumentation
+### :gear: useCommandRunnerCallback
 
-Generate documentation and write output to a file.
-If the file exists, it will try to insert the docs between <!-- TSDOC_START --> and <!-- TSDOC_END --> comments.
-If these does not exist, the output file will be overwritten.
+A hook that returns a callback function that can be used to run a command.
 
-| Function                | Type                                                                                                                                                                                                           |
-| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `generateDocumentation` | `({ inputFiles, outputFile, markdownOptions, buildOptions }: { inputFiles: string[]; outputFile: string; markdownOptions?: MarkdownOptions or undefined; buildOptions?: BuildOptions or undefined; }) => void` |
+| Function | Type |
+| ---------- | ---------- |
+| `useCommandRunnerCallback` | `(getSelection: () => SelectionKey[], isReadOnlyUser: boolean) => CommandRunner` |
 
 Parameters:
 
-- `params.inputFiles`: The list of files to scan for documentation. Absolute or relative path.
-- `params.outputFile`: The file to output the documentation in Markdown.
-- `params.markdownOptions`: Optional settings passed to the Markdown parser. See `MarkdownOptions` for details.
-- `params.buildOptions`: Options to construct the documentation tree. See `BuildOptions` for details.
+* `getSelection`: a function to retreive the current selection
+* `isReadOnlyUser`: a flag to indicate if the current user is read-only
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/index.ts#L26)
+
+### :gear: useRunnableCommand
+
+A hook that returns a runnable command object for the given command name and selection.
+
+| Function | Type |
+| ---------- | ---------- |
+| `useRunnableCommand` | `(currentSelection: SelectionKey[], name: CommandName, arg: string or undefined, isReadOnlyUser: boolean, selectionOverride?: SelectionKey[] or undefined) => RunnableCommand` |
+
+Parameters:
+
+* `currentSelection`: the current selection as an array
+* `name`: the name of the command
+* `arg`: an optional argument to pass to the command
+* `isReadOnlyUser`: a flag to indicate if the current user is read-only
+* `selectionOverride`: an optional override to the currentSelection
+
+
+
 
 <!-- TSDOC_END -->
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Generates markdown documentation from TypeScript source code. Useful for generat
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors-)
 
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -130,60 +130,58 @@ generateDocumentation({
 
 ## :toolbox: Functions
 
-- [buildRunner](#gear-buildrunner)
-- [useCommandRunnerCallback](#gear-usecommandrunnercallback)
-- [useRunnableCommand](#gear-userunnablecommand)
+- [buildDocumentation](#gear-builddocumentation)
+- [documentationToMarkdown](#gear-documentationtomarkdown)
+- [generateDocumentation](#gear-generatedocumentation)
 
-### :gear: buildRunner
+### :gear: buildDocumentation
 
-Builds a command runner for the given command name and selection.
-The built runner will have its handler property set to a function that will
-execute all available commands for the given command name.
+Build the documentation entries for the selected sources.
 
-| Function | Type |
-| ---------- | ---------- |
-| `buildRunner` | `(name: CommandName, selection: SelectionKey[], arg: string or undefined, isReadOnlyUser: boolean) => RunnableCommandInternal` |
+| Function             | Type                                                                                                      |
+| -------------------- | --------------------------------------------------------------------------------------------------------- |
+| `buildDocumentation` | `({ inputFiles, options }: { inputFiles: string[]; options?: BuildOptions or undefined; }) => DocEntry[]` |
 
 Parameters:
 
-* `name`: The name of the command to build a runner for
-* `selection`: The current selection
-* `arg`: The argument to pass to the command
-* `isReadOnlyUser`: Whether the current user is read-only
+- `params.inputFiles`: The list of files to scan and for which the documentation should be build.
+- `params.options`: Optional compiler options to generate the docs
 
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/docs.ts#L398)
 
-### :gear: useCommandRunnerCallback
+### :gear: documentationToMarkdown
 
-A hook that returns a callback function that can be used to run a command.
+Convert the documentation entries to an opinionated Markdown format.
 
-| Function | Type |
-| ---------- | ---------- |
-| `useCommandRunnerCallback` | `(getSelection: () => SelectionKey[], isReadOnlyUser: boolean) => CommandRunner` |
-
-Parameters:
-
-* `getSelection`: a function to retreive the current selection
-* `isReadOnlyUser`: a flag to indicate if the current user is read-only
-
-
-### :gear: useRunnableCommand
-
-A hook that returns a runnable command object for the given command name and selection.
-
-| Function | Type |
-| ---------- | ---------- |
-| `useRunnableCommand` | `(currentSelection: SelectionKey[], name: CommandName, arg: string or undefined, isReadOnlyUser: boolean, selectionOverride?: SelectionKey[] or undefined) => RunnableCommand` |
+| Function                  | Type                                                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `documentationToMarkdown` | `({ entries, options }: { entries: DocEntry[]; options?: MarkdownOptions or undefined; }) => string` |
 
 Parameters:
 
-* `currentSelection`: the current selection as an array
-* `name`: the name of the command
-* `arg`: an optional argument to pass to the command
-* `isReadOnlyUser`: a flag to indicate if the current user is read-only
-* `selectionOverride`: an optional override to the currentSelection
+- `params.entries`: The entries of the documentation (functions, constants and classes).
+- `params.options`: Optional configuration to render the Markdown content. See `types.ts` for details.
 
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/markdown.ts#L277)
 
+### :gear: generateDocumentation
 
+Generate documentation and write output to a file.
+If the file exists, it will try to insert the docs between <!-- TSDOC_START --> and <!-- TSDOC_END --> comments.
+If these does not exist, the output file will be overwritten.
+
+| Function                | Type                                                                                                                                                                                                           |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `generateDocumentation` | `({ inputFiles, outputFile, markdownOptions, buildOptions }: { inputFiles: string[]; outputFile: string; markdownOptions?: MarkdownOptions or undefined; buildOptions?: BuildOptions or undefined; }) => void` |
+
+Parameters:
+
+- `params.inputFiles`: The list of files to scan for documentation. Absolute or relative path.
+- `params.outputFile`: The file to output the documentation in Markdown.
+- `params.markdownOptions`: Optional settings passed to the Markdown parser. See `MarkdownOptions` for details.
+- `params.buildOptions`: Options to construct the documentation tree. See `BuildOptions` for details.
+
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/index.ts#L26)
 
 <!-- TSDOC_END -->
 
@@ -206,6 +204,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://daviddalbusco.com/"><img src="https://avatars.githubusercontent.com/u/16886711?v=4?s=48" width="48px;" alt="David Dal Busco"/><br /><sub><b>David Dal Busco</b></sub></a><br /><a href="https://github.com/peterpeterparker/tsdoc-markdown/commits?author=peterpeterparker" title="Code">💻</a> <a href="https://github.com/peterpeterparker/tsdoc-markdown/commits?author=peterpeterparker" title="Documentation">📖</a> <a href="#example-peterpeterparker" title="Examples">💡</a> <a href="#ideas-peterpeterparker" title="Ideas, Planning, & Feedback">🤔</a> <a href="#maintenance-peterpeterparker" title="Maintenance">🚧</a> <a href="#projectManagement-peterpeterparker" title="Project Management">📆</a> <a href="#research-peterpeterparker" title="Research">🔬</a> <a href="https://github.com/peterpeterparker/tsdoc-markdown/pulls?q=is%3Apr+reviewed-by%3Apeterpeterparker" title="Reviewed Pull Requests">👀</a> <a href="https://github.com/peterpeterparker/tsdoc-markdown/commits?author=peterpeterparker" title="Tests">⚠️</a> <a href="#tool-peterpeterparker" title="Tools">🔧</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://mia.cx/"><img src="https://avatars.githubusercontent.com/u/42698687?v=4?s=48" width="48px;" alt="Mia Riezebos"/><br /><sub><b>Mia Riezebos</b></sub></a><br /><a href="https://github.com/peterpeterparker/tsdoc-markdown/commits?author=mia-riezebos" title="Code">💻</a> <a href="#platform-mia-riezebos" title="Packaging/porting to new platform">📦</a> <a href="#research-mia-riezebos" title="Research">🔬</a> <a href="https://github.com/peterpeterparker/tsdoc-markdown/commits?author=mia-riezebos" title="Tests">⚠️</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/mingtianyihou33"><img src="https://avatars.githubusercontent.com/u/22953606?v=4?s=48" width="48px;" alt="mingtianyihou"/><br /><sub><b>mingtianyihou</b></sub></a><br /><a href="https://github.com/peterpeterparker/tsdoc-markdown/commits?author=mingtianyihou33" title="Code">💻</a> <a href="https://github.com/peterpeterparker/tsdoc-markdown/commits?author=mingtianyihou33" title="Tests">⚠️</a> <a href="#ideas-mingtianyihou33" title="Ideas, Planning, & Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/jordancardwell"><img src="https://avatars.githubusercontent.com/u/636339?v=4?s=48" width="48px;" alt="Jordan"/><br /><sub><b>Jordan</b></sub></a><br /><a href="https://github.com/peterpeterparker/tsdoc-markdown/commits?author=jordancardwell" title="Code">💻</a> <a href="https://github.com/peterpeterparker/tsdoc-markdown/commits?author=jordancardwell" title="Tests">⚠️</a></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Parameters:
 - `params.inputFiles`: The list of files to scan and for which the documentation should be build.
 - `params.options`: Optional compiler options to generate the docs
 
-[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/docs.ts#L398)
+[:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/lib/docs.ts#L498)
 
 ### :gear: documentationToMarkdown
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -38,6 +38,10 @@ const outputFile =
 
 const repoUrl = process.argv.find((arg) => arg.indexOf('--repo=') > -1)?.replace('--repo=', '');
 
+const repoBranch = process.argv
+  .find((arg) => arg.indexOf('--repoBranch=') > -1)
+  ?.replace('--repoBranch=', '');
+
 const types = process.argv.find((arg) => arg.indexOf('--types') > -1) !== undefined;
 
 if (!inputFiles || inputFiles.length === 0) {
@@ -47,12 +51,13 @@ if (!inputFiles || inputFiles.length === 0) {
 generateDocumentation({
   inputFiles,
   outputFile,
-  ...(repoUrl !== undefined && {
-    buildOptions: {
+  buildOptions: {
+    ...(repoUrl !== undefined && {
       repo: {
-        url: repoUrl
-      },
-      types
-    }
-  })
+        url: repoUrl,
+        branch: repoBranch
+      }
+    }),
+    types
+  }
 });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "jest",
     "start": "node rmdir.mjs && node esbuild.mjs && node bin/index.js --src=src/test/mock.ts --dest=src/test/mock.md --repo=https://github.com/peterpeterparker/tsdoc-markdown --types",
     "docs": "node rmdir.mjs && node esbuild.mjs && node bin/index.js --src=src/lib/* --repo=https://github.com/peterpeterparker/tsdoc-markdown && prettier --write ./README.md",
-    "prepare": "npm i && npm run build"
+    "prepare": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "ts-declaration": "tsc --emitDeclarationOnly --outDir dist/types",
     "test": "jest",
     "start": "node rmdir.mjs && node esbuild.mjs && node bin/index.js --src=src/test/mock.ts --dest=src/test/mock.md --repo=https://github.com/peterpeterparker/tsdoc-markdown --types",
-    "docs": "node rmdir.mjs && node esbuild.mjs && node bin/index.js --src=src/lib/* --repo=https://github.com/peterpeterparker/tsdoc-markdown && prettier --write ./README.md"
+    "docs": "node rmdir.mjs && node esbuild.mjs && node bin/index.js --src=src/lib/* --repo=https://github.com/peterpeterparker/tsdoc-markdown && prettier --write ./README.md",
+    "prepare": "yarn build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsdoc-markdown",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Generates markdown documentation from TypeScript source code.",
   "author": "David Dal Busco",
   "license": "MIT",
@@ -49,7 +49,8 @@
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
     "prettier-plugin-organize-imports": "^3.2.4",
-    "ts-jest": "^29.1.2"
+    "ts-jest": "^29.1.2",
+    "typescript": "^5.6.3"
   },
   "keywords": [
     "jsdoc",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "jest",
     "start": "node rmdir.mjs && node esbuild.mjs && node bin/index.js --src=src/test/mock.ts --dest=src/test/mock.md --repo=https://github.com/peterpeterparker/tsdoc-markdown --types",
     "docs": "node rmdir.mjs && node esbuild.mjs && node bin/index.js --src=src/lib/* --repo=https://github.com/peterpeterparker/tsdoc-markdown && prettier --write ./README.md",
-    "prepare": "yarn build"
+    "prepare": "npm i && npm run build"
   },
   "repository": {
     "type": "git",

--- a/src/lib/docs.ts
+++ b/src/lib/docs.ts
@@ -165,31 +165,8 @@ function collectExportedNames(sourceFile: SourceFile): Set<string> {
   return exportedNames;
 }
 
-/** True if this is visible outside this file, false otherwise */
-// const isNodeExportedOrPublic = (node: Node, exportedNodes: Set<Node>): boolean => {
-//   const flags = getCombinedModifierFlags(node as Declaration);
-
-//   // if (
-//   //   (flags & ModifierFlags.Export) !== 0 ||
-//   //   (flags & ModifierFlags.Public) !== 0 ||
-//   //   (isClassDeclaration(node.parent) && [ModifierFlags.None, ModifierFlags.Static].includes(flags))
-//   // ) {
-//   //   return true;
-//   // }
-
-//   if (exportedNodes.has(node)) {
-//     console.log('Node INDEED exported', node.getText());
-//     return true;
-//   }
-
-//   console.log('Node NOT exported', node.getText());
-//   return false;
-// };
-
 function isNodeExportedOrPublic(node: Node, exportedNames: Set<string>): boolean {
   let name: string | undefined;
-  console.log('CHECKING', node.getText());
-  // Handle VariableStatement specifically
   if (isVariableStatement(node)) {
     // Check if the VariableStatement itself is exported
     const isExportedStatement = node.modifiers?.some(
@@ -202,7 +179,6 @@ function isNodeExportedOrPublic(node: Node, exportedNames: Set<string>): boolean
     // Otherwise, check each declaration
     for (const declaration of node.declarationList.declarations) {
       if (isIdentifier(declaration.name) && exportedNames.has(declaration.name.text)) {
-        console.log('Node EXPORTED', node.getText());
         return true;
       }
     }
@@ -233,15 +209,6 @@ function isNodeExportedOrPublic(node: Node, exportedNames: Set<string>): boolean
     flags |= parentFlags;
   }
 
-  if (
-    (flags & ModifierFlags.Export) !== 0 ||
-    (flags & ModifierFlags.Public) !== 0 ||
-    (isClassDeclaration(node.parent) &&
-      [ModifierFlags.None, ModifierFlags.Static].includes(flags)) ||
-    (!!name && exportedNames.has(name))
-  ) {
-    console.log('Node EXPORTED', node.getText());
-  }
   return (
     (flags & ModifierFlags.Export) !== 0 ||
     (flags & ModifierFlags.Public) !== 0 ||
@@ -572,7 +539,6 @@ export const buildDocumentation = ({
     // Collect exported nodes from the source file
     const exportedNames = collectExportedNames(sourceFile);
 
-    console.log('exportedNames', exportedNames.values());
     // Walk the tree to search for classes
     forEachChild(sourceFile, (node: Node) => {
       const entries: DocEntry[] = visit({

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -289,7 +289,7 @@ export const documentationToMarkdown = ({
   const headingLevel = userHeadingLevel ?? '##';
 
   const emoji: MarkdownEmoji | undefined =
-    userEmoji === null ? undefined : userEmoji ?? DEFAULT_EMOJI;
+    userEmoji === null ? undefined : (userEmoji ?? DEFAULT_EMOJI);
 
   const functions: DocEntry[] = entries.filter(({doc_type}: DocEntry) => doc_type === 'function');
   const classes: DocEntry[] = entries.filter(({doc_type}: DocEntry) => doc_type === 'class');

--- a/src/test/docs.spec.ts
+++ b/src/test/docs.spec.ts
@@ -31,20 +31,23 @@ describe('docs', () => {
     });
   });
 
-  it('should correctly detect exported/public ', () => {
+  describe('bulk exports', () => {
     const doc = buildDocumentation({
       inputFiles: ['./src/test/mock.ts'],
       options: {
         repo: {
           url: 'https://github.com/peterpeterparker/tsdoc-markdown/'
-        }
+        },
+        types: true
       }
     });
 
-    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
-    expect(doc[0]).toEqual({
-      ...JSON.parse(expectedDoc)[0],
-      url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L6'
-    });
+    it.each([['hello'], ['numberOne'], ['Abc']])(
+      'should include bulk exported item: %s',
+      (name) => {
+        const item = doc.find((item) => item.name === name);
+        expect(item).toBeDefined();
+      }
+    );
   });
 });

--- a/src/test/docs.spec.ts
+++ b/src/test/docs.spec.ts
@@ -1,8 +1,8 @@
 import {readFileSync} from 'fs';
 import {buildDocumentation} from '../lib/docs';
 
-describe('docs', () => {
-  it('should generate json for mock', () => {
+describe.skip('docs', () => {
+  it.only('should generate json for mock', () => {
     const doc = buildDocumentation({
       inputFiles: ['./src/test/mock.ts'],
       options: {
@@ -11,10 +11,29 @@ describe('docs', () => {
     });
 
     const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    //TODO: update tests then remove this
+    //writeFileSync('./src/test/updatedMock.json', JSON.stringify(doc, null, 2));
     expect(doc).toEqual(JSON.parse(expectedDoc));
   });
 
   it('should generate json with links to source code', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock.ts'],
+      options: {
+        repo: {
+          url: 'https://github.com/peterpeterparker/tsdoc-markdown/'
+        }
+      }
+    });
+
+    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    expect(doc[0]).toEqual({
+      ...JSON.parse(expectedDoc)[0],
+      url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L6'
+    });
+  });
+
+  it('should correctly detect exported/public ', () => {
     const doc = buildDocumentation({
       inputFiles: ['./src/test/mock.ts'],
       options: {

--- a/src/test/docs.spec.ts
+++ b/src/test/docs.spec.ts
@@ -1,8 +1,8 @@
 import {readFileSync} from 'fs';
 import {buildDocumentation} from '../lib/docs';
 
-describe.skip('docs', () => {
-  it.only('should generate json for mock', () => {
+describe('docs', () => {
+  it('should generate json for mock', () => {
     const doc = buildDocumentation({
       inputFiles: ['./src/test/mock.ts'],
       options: {
@@ -11,8 +11,6 @@ describe.skip('docs', () => {
     });
 
     const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
-    //TODO: update tests then remove this
-    //writeFileSync('./src/test/updatedMock.json', JSON.stringify(doc, null, 2));
     expect(doc).toEqual(JSON.parse(expectedDoc));
   });
 

--- a/src/test/markdown.spec.ts
+++ b/src/test/markdown.spec.ts
@@ -1,11 +1,11 @@
-import {readFileSync, writeFileSync} from 'fs';
+import {readFileSync} from 'fs';
 import {documentationToMarkdown} from '../lib';
 import {buildDocumentation} from '../lib/docs';
 
 describe('markdown', () => {
   it('should generate markdown for mock', () => {
     const doc = buildDocumentation({
-      inputFiles: ['./src/test/newmock.ts'],
+      inputFiles: ['./src/test/mock.ts'],
       options: {
         repo: {
           url: 'https://github.com/peterpeterparker/tsdoc-markdown'
@@ -17,16 +17,10 @@ describe('markdown', () => {
       entries: doc
     });
     const expectedDoc = readFileSync('./src/test/mock.md', 'utf8').replace(/\r\n/g, '\n');
-    //TODO: update tests then remove this
-    writeFileSync(
-      './src/test/newMock.md',
-      JSON.stringify(markdown.replace(/\r\n/g, '\n'), null, 2)
-    );
-
-    // expect(markdown).toEqual(expectedDoc);
+    expect(markdown).toEqual(expectedDoc);
   });
 
-  it.skip.each([35, 86, 114])('should generate a markdown link to line %s', (line) => {
+  it.each([35, 86, 114])('should generate a markdown link to line %s', (line) => {
     const doc = buildDocumentation({
       inputFiles: ['./src/test/mock.ts'],
       options: {

--- a/src/test/markdown.spec.ts
+++ b/src/test/markdown.spec.ts
@@ -1,11 +1,11 @@
-import {readFileSync} from 'fs';
+import {readFileSync, writeFileSync} from 'fs';
 import {documentationToMarkdown} from '../lib';
 import {buildDocumentation} from '../lib/docs';
 
 describe('markdown', () => {
   it('should generate markdown for mock', () => {
     const doc = buildDocumentation({
-      inputFiles: ['./src/test/mock.ts'],
+      inputFiles: ['./src/test/newmock.ts'],
       options: {
         repo: {
           url: 'https://github.com/peterpeterparker/tsdoc-markdown'
@@ -17,11 +17,16 @@ describe('markdown', () => {
       entries: doc
     });
     const expectedDoc = readFileSync('./src/test/mock.md', 'utf8').replace(/\r\n/g, '\n');
+    //TODO: update tests then remove this
+    writeFileSync(
+      './src/test/newMock.md',
+      JSON.stringify(markdown.replace(/\r\n/g, '\n'), null, 2)
+    );
 
-    expect(markdown).toEqual(expectedDoc);
+    // expect(markdown).toEqual(expectedDoc);
   });
 
-  it.each([35, 86, 114])('should generate a markdown link to line %s', (line) => {
+  it.skip.each([35, 86, 114])('should generate a markdown link to line %s', (line) => {
     const doc = buildDocumentation({
       inputFiles: ['./src/test/mock.ts'],
       options: {

--- a/src/test/mock.json
+++ b/src/test/mock.json
@@ -134,6 +134,23 @@
                 "kind": "text"
               }
             ]
+          },
+          {
+            "name": "param",
+            "text": [
+              {
+                "text": "params.canisterId",
+                "kind": "parameterName"
+              },
+              {
+                "text": " ",
+                "kind": "space"
+              },
+              {
+                "text": "An optional canisterId",
+                "kind": "text"
+              }
+            ]
           }
         ],
         "doc_type": "method"
@@ -148,6 +165,23 @@
             "text": [
               {
                 "text": "params",
+                "kind": "text"
+              }
+            ]
+          },
+          {
+            "name": "param",
+            "text": [
+              {
+                "text": "params.certified",
+                "kind": "parameterName"
+              },
+              {
+                "text": " ",
+                "kind": "space"
+              },
+              {
+                "text": "Update calls?",
                 "kind": "text"
               }
             ]
@@ -204,6 +238,23 @@
             "text": [
               {
                 "text": "params",
+                "kind": "text"
+              }
+            ]
+          },
+          {
+            "name": "param",
+            "text": [
+              {
+                "text": "params.canisterId",
+                "kind": "parameterName"
+              },
+              {
+                "text": " ",
+                "kind": "space"
+              },
+              {
+                "text": "An optional canisterId",
                 "kind": "text"
               }
             ]

--- a/src/test/mock.json
+++ b/src/test/mock.json
@@ -503,7 +503,7 @@
   {
     "name": "SatelliteConfig",
     "documentation": "",
-    "type": "Either<SatelliteId, SatelliteIds> &\n    CliConfig &\n    SatelliteConfigOptions",
+    "type": "Either<SatelliteId, SatelliteIds> &\n  CliConfig &\n  SatelliteConfigOptions",
     "jsDocs": [],
     "doc_type": "type",
     "fileName": "src/test/mock.ts"

--- a/src/test/mock.md
+++ b/src/test/mock.md
@@ -134,6 +134,11 @@ Create a LedgerCanister
 | ---------- | ---------- |
 | `create` | `(options: { canisterId?: string or undefined; }) => LedgerCanister` |
 
+Parameters:
+
+* `params.canisterId`: An optional canisterId
+
+
 [:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L55)
 
 #### :gear: accountBalance
@@ -143,6 +148,11 @@ Returns the balance of the specified account identifier.
 | Method | Type |
 | ---------- | ---------- |
 | `accountBalance` | `({ certified }: { certified?: boolean or undefined; }) => Promise<{ icp: bigint; }>` |
+
+Parameters:
+
+* `params.certified`: Update calls?
+
 
 [:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L69)
 
@@ -169,6 +179,11 @@ This create function is public as well.
 | Method | Type |
 | ---------- | ---------- |
 | `create` | `(options: { canisterId?: string or undefined; }) => SnsLedgerCanister` |
+
+Parameters:
+
+* `params.canisterId`: An optional canisterId
+
 
 [:link: Source](https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L101)
 

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -3,12 +3,12 @@
  *
  * @param yolo this is a jsdoc
  */
-export const hello = (world: string): string => 'hello' + world;
+const hello = (world: string): string => 'hello' + world;
 
 /**
  * A constant
  */
-export const numberOne = 2;
+const numberOne = 2;
 
 /**
  * hello2
@@ -243,5 +243,7 @@ export interface StorageConfigRedirect {
 }
 
 export type SatelliteConfig = Either<SatelliteId, SatelliteIds> &
-    CliConfig &
-    SatelliteConfigOptions;
+  CliConfig &
+  SatelliteConfigOptions;
+
+export {hello, numberOne};

--- a/src/test/mock.ts
+++ b/src/test/mock.ts
@@ -145,7 +145,7 @@ export type yolo = 'string';
 /**
  * A type yolo
  */
-export type Abc = Foo & {hello: string};
+type Abc = Foo & {hello: string};
 
 export enum Time {
   SECOND = 1000,
@@ -247,3 +247,4 @@ export type SatelliteConfig = Either<SatelliteId, SatelliteIds> &
   SatelliteConfigOptions;
 
 export {hello, numberOne};
+export type {Abc};


### PR DESCRIPTION
Adds support for:
* generating docs for bulk exported items
  * initially only supported inline exports
* adds support for the `--repoBranch` option when executing bin
  * previously only presumed `main` branch
* makes the `--type` option respected, regardless of whether `--repo` is provided
* fix tests
