### PR TITLE
Adds support for package.json repository structure to url generation [ODY-1099]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,21 @@
 {
   "name": "tsdoc-markdown",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tsdoc-markdown",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "MIT",
+      "dependencies": {
+        "hosted-git-info": "^8.0.2"
+      },
       "bin": {
         "tsdoc": "bin/index.js"
       },
       "devDependencies": {
+        "@types/hosted-git-info": "^3.0.5",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.18",
         "@typescript-eslint/eslint-plugin": "^7.0.1",
@@ -25,7 +29,8 @@
         "jest": "^29.7.0",
         "prettier": "^3.2.5",
         "prettier-plugin-organize-imports": "^3.2.4",
-        "ts-jest": "^29.1.2"
+        "ts-jest": "^29.1.2",
+        "typescript": "^5.6.3"
       },
       "peerDependencies": {
         "typescript": "^5"
@@ -1687,6 +1692,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/hosted-git-info": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
+      "integrity": "sha512-Dmngh7U003cOHPhKGyA7LWqrnvcTyILNgNPmNCxlx7j8MIi54iBliiT8XqVLIQ3GchoOjVAyBzNJVyuaJjqokg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -4137,6 +4149,24 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.0.2.tgz",
+      "integrity": "sha512-sYKnA7eGln5ov8T8gnYlkSOxFJvywzEx9BueN6xo/GKO8PGiI6uK6xx+DIGe45T3bdVjLAQDQW1aicT8z8JwQg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -6754,10 +6784,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "peer": true,
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8188,6 +8219,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/hosted-git-info": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hosted-git-info/-/hosted-git-info-3.0.5.tgz",
+      "integrity": "sha512-Dmngh7U003cOHPhKGyA7LWqrnvcTyILNgNPmNCxlx7j8MIi54iBliiT8XqVLIQ3GchoOjVAyBzNJVyuaJjqokg==",
+      "dev": true
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -9943,6 +9980,21 @@
       "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
+      }
+    },
+    "hosted-git-info": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-8.0.2.tgz",
+      "integrity": "sha512-sYKnA7eGln5ov8T8gnYlkSOxFJvywzEx9BueN6xo/GKO8PGiI6uK6xx+DIGe45T3bdVjLAQDQW1aicT8z8JwQg==",
+      "requires": {
+        "lru-cache": "^10.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.4.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+          "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+        }
       }
     },
     "html-escaper": {
@@ -11824,10 +11876,10 @@
       }
     },
     "typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "peer": true
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "url": "https://github.com/peterpeterparker/tsdoc-markdown"
   },
   "devDependencies": {
+    "@types/hosted-git-info": "^3.0.5",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.18",
     "@typescript-eslint/eslint-plugin": "^7.0.1",
@@ -66,5 +67,8 @@
   ],
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "dependencies": {
+    "hosted-git-info": "^8.0.2"
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -57,8 +57,10 @@ export interface MarkdownOptions {
 }
 
 export interface RepoOptions {
+  type?: string;
   url: string;
   // Default: "main" branch
+  directory?: string;
   branch?: string;
 }
 
@@ -71,7 +73,7 @@ export interface BuildOptions {
   // `false` per default to limit the scope of the documentation to the input files only. If turns to `true`, all files of the program will be analyzed to generate the documentation.
   explore?: boolean;
   // If provided, the Markdown parser will generate links to the documented source code
-  repo?: RepoOptions;
+  repo?: RepoOptions | string;
   // Documentation for Interfaces and Types is not generated per default. Set to true to include those.
   types?: boolean;
 }

--- a/src/test/docs.spec.ts
+++ b/src/test/docs.spec.ts
@@ -31,6 +31,127 @@ describe('docs', () => {
     });
   });
 
+  it('should generate json with links to source code with npm shorthand syntax', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock.ts'],
+      options: {
+        repo: 'peterpeterparker/tsdoc-markdown'
+      }
+    });
+
+    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    expect(doc[0]).toEqual({
+      ...JSON.parse(expectedDoc)[0],
+      url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L6'
+    });
+  });
+
+  it('should generate json with links to source code with github shorthand syntax', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock.ts'],
+      options: {
+        repo: 'github:peterpeterparker/tsdoc-markdown'
+      }
+    });
+
+    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    expect(doc[0]).toEqual({
+      ...JSON.parse(expectedDoc)[0],
+      url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/main/src/test/mock.ts#L6'
+    });
+  });
+
+  it('should generate json with links to source code with gitlab shorthand syntax', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock.ts'],
+      options: {
+        repo: 'gitlab:peterpeterparker/tsdoc-markdown'
+      }
+    });
+
+    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    expect(doc[0]).toEqual({
+      ...JSON.parse(expectedDoc)[0],
+      url: 'https://gitlab.com/peterpeterparker/tsdoc-markdown/-/blob/main/src/test/mock.ts#L6'
+    });
+  });
+
+  it('should generate json with links to source code with github repository https url', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock.ts'],
+      options: {
+        repo: {
+          type: 'git',
+          url: 'git+https://github.com/peterpeterparker/tsdoc-markdown.git',
+          directory: 'packages/test',
+          branch: 'testing'
+        }
+      }
+    });
+
+    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    expect(doc[0]).toEqual({
+      ...JSON.parse(expectedDoc)[0],
+      url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/testing/packages/test/src/test/mock.ts#L6'
+    });
+  });
+
+  it('should generate json with links to source code with github repository ssh url', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock.ts'],
+      options: {
+        repo: {
+          type: 'git',
+          url: 'git@github.com/peterpeterparker/tsdoc-markdown.git',
+          directory: 'packages/test',
+          branch: 'testing'
+        }
+      }
+    });
+
+    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    expect(doc[0]).toEqual({
+      ...JSON.parse(expectedDoc)[0],
+      url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/testing/packages/test/src/test/mock.ts#L6'
+    });
+  });
+
+  it('should generate json with links to source code in directory without trailing slash', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock.ts'],
+      options: {
+        repo: {
+          url: 'https://github.com/peterpeterparker/tsdoc-markdown/',
+          directory: 'packages/test'
+        }
+      }
+    });
+
+    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    expect(doc[0]).toEqual({
+      ...JSON.parse(expectedDoc)[0],
+      url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/main/packages/test/src/test/mock.ts#L6'
+    });
+  });
+
+  it('should generate json with links to source code in directory with trailing slash', () => {
+    const doc = buildDocumentation({
+      inputFiles: ['./src/test/mock.ts'],
+      options: {
+        repo: {
+          url: 'https://github.com/peterpeterparker/tsdoc-markdown/',
+          directory: 'packages/test/'
+        }
+      }
+    });
+
+    const expectedDoc = readFileSync('./src/test/mock.json', 'utf8');
+    expect(doc[0]).toEqual({
+      ...JSON.parse(expectedDoc)[0],
+      url: 'https://github.com/peterpeterparker/tsdoc-markdown/tree/main/packages/test/src/test/mock.ts#L6'
+    });
+  });
+
   describe('bulk exports', () => {
     const doc = buildDocumentation({
       inputFiles: ['./src/test/mock.ts'],


### PR DESCRIPTION
## Motivation

As a part of ODY-1099, I realized the urls being generated in the documentation do not link to the appropriate files in the Onebrief/bc monorepo. Package.json has support for this out of the box when using `npm repo` so chose to borrow from their standard.

## Summary of changes

Adds `npm/hosted-git-info`
Updates RepoOptions type
Adds logic to support more url and repo strategies in-line with npm `package.json` repository object format
Maintains backwards compatibility